### PR TITLE
Add missing import to fix build

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/list/RecipeListScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/list/RecipeListScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester


### PR DESCRIPTION
Import has been deleted in https://github.com/lneugebauer/nextcloud-cookbook/commit/fa11ed92fc325fea57e65caa9ce0280883e4282b.