### PR TITLE
More suggestions

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/PreferencesManager.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/PreferencesManager.kt
@@ -13,8 +13,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import de.lukasneugebauer.nextcloudcookbook.core.domain.model.NcAccount
-import de.lukasneugebauer.nextcloudcookbook.core.domain.model.RecipeOfTheDay
-import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.DEFAULT_RECIPE_OF_THE_DAY_ID
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.STAY_AWAKE_DEFAULT
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.STAY_AWAKE_KEY
 import kotlinx.coroutines.flow.catch
@@ -22,9 +20,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import java.io.IOException
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -81,8 +76,6 @@ class PreferencesManager
             val NC_USERNAME = stringPreferencesKey("nc_username")
             val NC_TOKEN = stringPreferencesKey("nc_token")
             val NC_URL = stringPreferencesKey("nc_url")
-            val RECIPE_OF_THE_DAY_ID = stringPreferencesKey("recipe_of_the_day_id")
-            val RECIPE_OF_THE_DAY_UPDATED_AT = longPreferencesKey("recipe_of_the_day_updated_at")
         }
 
         val preferencesFlow =
@@ -100,9 +93,6 @@ class PreferencesManager
                     val ncUsername = preferences[PreferencesKeys.NC_USERNAME] ?: ""
                     val ncToken = preferences[PreferencesKeys.NC_TOKEN] ?: ""
                     val ncUrl = preferences[PreferencesKeys.NC_URL] ?: ""
-                    val recipeOfTheDayId = preferences[PreferencesKeys.RECIPE_OF_THE_DAY_ID] ?: DEFAULT_RECIPE_OF_THE_DAY_ID
-                    val recipeOfTheDayUpdatedAt =
-                        preferences[PreferencesKeys.RECIPE_OF_THE_DAY_UPDATED_AT] ?: 0
 
                     de.lukasneugebauer.nextcloudcookbook.core.domain.model.Preferences(
                         ncAccount =
@@ -111,18 +101,7 @@ class PreferencesManager
                                 username = ncUsername,
                                 token = ncToken,
                                 url = ncUrl,
-                            ),
-                        recipeOfTheDay =
-                            RecipeOfTheDay(
-                                id = recipeOfTheDayId,
-                                updatedAt =
-                                    LocalDateTime.ofInstant(
-                                        Instant.ofEpochSecond(
-                                            recipeOfTheDayUpdatedAt,
-                                        ),
-                                        ZoneOffset.UTC,
-                                    ),
-                            ),
+                            )
                     )
                 }
 
@@ -140,13 +119,6 @@ class PreferencesManager
                 preferences[PreferencesKeys.NC_USERNAME] = ncAccount.username
                 preferences[PreferencesKeys.NC_TOKEN] = ncAccount.token
                 preferences[PreferencesKeys.NC_URL] = ncAccount.url
-            }
-
-        suspend fun updateRecipeOfTheDay(recipeOfTheDay: RecipeOfTheDay) =
-            context.dataStore54.edit { preferences ->
-                preferences[PreferencesKeys.RECIPE_OF_THE_DAY_ID] = recipeOfTheDay.id
-                preferences[PreferencesKeys.RECIPE_OF_THE_DAY_UPDATED_AT] =
-                    recipeOfTheDay.updatedAt.toEpochSecond(ZoneOffset.UTC)
             }
 
         suspend fun clearPreferences() {

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/model/Preferences.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/model/Preferences.kt
@@ -1,6 +1,5 @@
 package de.lukasneugebauer.nextcloudcookbook.core.domain.model
 
 data class Preferences(
-    val ncAccount: NcAccount,
-    val recipeOfTheDay: RecipeOfTheDay,
+    val ncAccount: NcAccount
 )

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/Constants.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/Constants.kt
@@ -5,7 +5,7 @@ import de.lukasneugebauer.nextcloudcookbook.BuildConfig
 object Constants {
     const val API_ENDPOINT: String = "index.php/apps/cookbook/api"
     private const val API_VERSION: String = "/v1"
-    const val DEFAULT_RECIPE_OF_THE_DAY_ID: String = "0"
+    const val RANDOM_RECIPES_ON_HOME: Int = 12
     const val FULL_PATH: String = API_ENDPOINT + API_VERSION
     const val SHARED_PREFERENCES_KEY: String = BuildConfig.APPLICATION_ID + ".SHARED_PREFERENCES"
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
@@ -1,23 +1,19 @@
 package de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase
 
+import android.content.Context
 import de.lukasneugebauer.nextcloudcookbook.R
-import de.lukasneugebauer.nextcloudcookbook.core.data.PreferencesManager
-import de.lukasneugebauer.nextcloudcookbook.core.domain.model.RecipeOfTheDay
-import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.DEFAULT_RECIPE_OF_THE_DAY_ID
+import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.RANDOM_RECIPES_ON_HOME
 import de.lukasneugebauer.nextcloudcookbook.core.util.IoDispatcher
 import de.lukasneugebauer.nextcloudcookbook.di.CategoriesStore
 import de.lukasneugebauer.nextcloudcookbook.di.RecipePreviewsByCategoryStore
 import de.lukasneugebauer.nextcloudcookbook.di.RecipePreviewsStore
-import de.lukasneugebauer.nextcloudcookbook.di.RecipeStore
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.HomeScreenDataResult
+import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.RecipePreview
 import de.lukasneugebauer.nextcloudcookbook.recipe.util.RecipeConstants
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.mobilenativefoundation.store.store5.impl.extensions.get
 import timber.log.Timber
-import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,49 +23,35 @@ class GetHomeScreenDataUseCase
     constructor(
         private val categoriesStore: CategoriesStore,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-        private val preferencesManager: PreferencesManager,
         private val recipePreviewsByCategoryStore: RecipePreviewsByCategoryStore,
         private val recipePreviewsStore: RecipePreviewsStore,
-        private val recipeStore: RecipeStore,
     ) {
         suspend operator fun invoke(): List<HomeScreenDataResult> {
-            val currentDate =
-                LocalDateTime.now()
-                    .withHour(0)
-                    .withMinute(0)
-                    .withSecond(0)
             val homeScreenData = mutableListOf<HomeScreenDataResult>()
-            var recipeOfTheDay = preferencesManager.preferencesFlow.map { it.recipeOfTheDay }.first()
+            var randomRecipes: List<RecipePreview> = emptyList()
 
-            if (recipeOfTheDay.id == DEFAULT_RECIPE_OF_THE_DAY_ID || recipeOfTheDay.updatedAt.isBefore(currentDate)) {
-                try {
-                    val newRecipeOfTheDayId =
-                        recipePreviewsStore.get(Unit).randomOrNull()?.toRecipePreview()?.id
-                            ?: DEFAULT_RECIPE_OF_THE_DAY_ID
-
-                    recipeOfTheDay =
-                        RecipeOfTheDay(
-                            id = newRecipeOfTheDayId,
-                            updatedAt = LocalDateTime.now(),
-                        )
-                    preferencesManager.updateRecipeOfTheDay(recipeOfTheDay)
-                } catch (e: Exception) {
-                    Timber.e(e.stackTraceToString())
-                }
+            try {
+                randomRecipes = recipePreviewsStore
+                    .get(Unit)
+                    .shuffled()
+                    .take(RANDOM_RECIPES_ON_HOME)
+                    .map { it.toRecipePreview() }
+            } catch (e: Exception) {
+                Timber.e(e.stackTraceToString())
             }
 
-            // FIXME: 25.12.21 Get different recipe of the day if api returns 404 error.
-            //  E.g. after deleting recipe of the day.
-            withContext(ioDispatcher) {
-                try {
-                    val result =
-                        HomeScreenDataResult.Single(
-                            R.string.home_recommendation,
-                            recipeStore.get(recipeOfTheDay.id).toRecipe(),
-                        )
-                    homeScreenData.add(result)
-                } catch (e: Exception) {
-                    Timber.e(e.stackTraceToString())
+            if (randomRecipes.isNotEmpty()) {
+                withContext(ioDispatcher) {
+                    try {
+                        val result =
+                            HomeScreenDataResult.Row(
+                                "context.getString(R.string.home_recommendations)", // TODO
+                                randomRecipes
+                            )
+                        homeScreenData.add(result)
+                    } catch (e: Exception) {
+                        Timber.e(e.stackTraceToString())
+                    }
                 }
             }
 

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/list/RecipeListScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/list/RecipeListScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="error_timeout">Timeout error</string>
     <string name="error_unknown_host">Unknown host</string>
     <string name="error_unknown">An unknown error occurred</string>
-    <string name="home_recommendation">Recommendation</string>
+    <string name="home_recommendations">Recommendations</string>
     <string name="login">Sign in</string>
     <string name="login_example_url" translatable="false">https://cloud.example.tld</string>
     <string name="login_manual">Manual sign in</string>


### PR DESCRIPTION
Use a row view to display more than one random recipe. This also removes
the "recipe of the day" logic from the app.

Closes https://github.com/lneugebauer/nextcloud-cookbook/issues/142

It also avoid the super large image for the suggestions as mentioned in #124.