### PR TITLE
fix(auth): use /cloud/user endpoint instead of /cloud/users/{id} for login

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/api/NcCookbookApi.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/api/NcCookbookApi.kt
@@ -33,10 +33,8 @@ interface NcCookbookApi {
         "OCS-APIRequest: true",
         "Content-Type: application/json;charset=utf-8",
     )
-    @GET("ocs/v2.php/cloud/users/{username}?format=json")
-    suspend fun getUserMetadata(
-        @Path("username") username: String,
-    ): NetworkResponse<UserMetadataResponse, ErrorResponse>
+    @GET("ocs/v2.php/cloud/user?format=json")
+    suspend fun getCurrentUser(): NetworkResponse<UserMetadataResponse, ErrorResponse>
 
     @GET("$FULL_PATH/categories")
     suspend fun getCategories(): List<CategoryDto>

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/repository/AccountRepositoryImpl.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/repository/AccountRepositoryImpl.kt
@@ -16,7 +16,6 @@ import de.lukasneugebauer.nextcloudcookbook.di.ApiProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.acra.ACRA
@@ -53,9 +52,8 @@ class AccountRepositoryImpl
                 val api =
                     apiProvider.getNcCookbookApi()
                         ?: return@withContext Resource.Error(message = UiText.StringResource(R.string.error_api_not_initialized))
-                val username = preferencesManager.preferencesFlow.map { it.ncAccount.username }.first()
 
-                when (val response = api.getUserMetadata(username)) {
+                when (val response = api.getCurrentUser()) {
                     is NetworkResponse.Success -> {
                         val result = response.body.ocs.data.toUserMetadata()
                         Resource.Success(data = result)


### PR DESCRIPTION
**Summary**
Switch login from `GET /ocs/v2.php/cloud/users/{id}` (admin-only) to `GET /ocs/v2.php/cloud/user` (current user). This fixes logins for non-admin accounts (e.g., LDAP/IMAP), because the previous endpoint returns 401/403 unless the authenticating user has admin permissions.

**Why**
The app fetched the user profile during login using `/cloud/users/{id}`. On servers where regular users (LDAP/IMAP) are not admins, this endpoint is forbidden and breaks the login. `/cloud/user` returns the authenticated user’s info and works for all accounts.

**How tested**
- Built a debug APK and installed on a Pixel 6a (Android 16).
- Captured logs with `adb logcat` filtered for `okhttp/ocs/auth/token`.
- Second login run (correct credentials flow) shows only 200 responses:
  - `GET /ocs/v2.php/cloud/user` → 200
  - subsequent Cookbook API calls (recipes, categories, version) → 200
- Login succeeds and the app loads data as expected.

**Notes**
- This likely resolves the same login failure reported for IMAP/LDAP users in the linked issue.