### PR TITLE
Fix forced logout when server is not reachable

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/manual/ManualLoginViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/manual/ManualLoginViewModel.kt
@@ -113,16 +113,6 @@ class ManualLoginViewModel
                                     userMetadata is Resource.Success -> {
                                         _uiState.update { ManualLoginScreenState.Authenticated }
                                     }
-                                    userMetadata is Resource.Error && userMetadata.isAuthError -> {
-                                        // Only clear credentials on actual auth errors (401/403)
-                                        clearPreferencesUseCase()
-                                        _uiState.update {
-                                            ManualLoginScreenState.Error(
-                                                uiText = userMetadata.message ?: UiText.StringResource(R.string.error_unknown),
-                                                username = account.data?.username ?: "",
-                                            )
-                                        }
-                                    }
                                     userMetadata is Resource.Error -> {
                                         // Network error - don't clear credentials, just show error
                                         _uiState.update {

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginViewModel.kt
@@ -89,15 +89,6 @@ class WebViewLoginViewModel
                                     userMetadata is Resource.Success -> {
                                         _uiState.update { WebViewScreenState.Authenticated }
                                     }
-                                    userMetadata is Resource.Error && userMetadata.isAuthError -> {
-                                        // Only clear credentials on actual auth errors (401/403)
-                                        clearPreferencesUseCase()
-                                        _uiState.update {
-                                            WebViewScreenState.Error(
-                                                uiText = userMetadata.message ?: UiText.StringResource(R.string.error_unknown),
-                                            )
-                                        }
-                                    }
                                     userMetadata is Resource.Error -> {
                                         // Network error - don't clear credentials, just show error
                                         _uiState.update {

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/NetworkErrorException.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/NetworkErrorException.kt
@@ -1,0 +1,5 @@
+package de.lukasneugebauer.nextcloudcookbook.core.domain
+
+class NetworkErrorException(
+    cause: Throwable,
+) : Exception(cause)

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/repository/BaseRepository.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/repository/BaseRepository.kt
@@ -22,13 +22,20 @@ open class BaseRepository {
         if (!serverMessage.isNullOrBlank()) return Resource.Error(UiText.DynamicString(serverMessage))
 
         var message = unknownErrorUiText(null)
+        var isAuthError = false
 
         if (code != null) {
             message =
                 when (code) {
                     400 -> UiText.StringResource(R.string.error_http_400)
-                    401 -> UiText.StringResource(R.string.error_http_401)
-                    403 -> UiText.StringResource(R.string.error_http_403)
+                    401 -> {
+                        isAuthError = true
+                        UiText.StringResource(R.string.error_http_401)
+                    }
+                    403 -> {
+                        isAuthError = true
+                        UiText.StringResource(R.string.error_http_403)
+                    }
                     404 -> UiText.StringResource(R.string.error_http_404)
                     405 -> UiText.StringResource(R.string.error_http_405)
                     500 -> UiText.StringResource(R.string.error_http_500)
@@ -43,8 +50,14 @@ open class BaseRepository {
                     is HttpException ->
                         when (t.code()) {
                             400 -> UiText.StringResource(R.string.error_http_400)
-                            401 -> UiText.StringResource(R.string.error_http_401)
-                            403 -> UiText.StringResource(R.string.error_http_403)
+                            401 -> {
+                                isAuthError = true
+                                UiText.StringResource(R.string.error_http_401)
+                            }
+                            403 -> {
+                                isAuthError = true
+                                UiText.StringResource(R.string.error_http_403)
+                            }
                             404 -> UiText.StringResource(R.string.error_http_404)
                             405 -> UiText.StringResource(R.string.error_http_405)
                             500 -> UiText.StringResource(R.string.error_http_500)
@@ -60,7 +73,7 @@ open class BaseRepository {
                     else -> unknownErrorUiText(t)
                 }
         }
-        return Resource.Error(message)
+        return Resource.Error(message, isAuthError = isAuthError)
     }
 
     private fun unknownErrorUiText(t: Throwable?): UiText =

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/presentation/error/ServerUnreachableScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/presentation/error/ServerUnreachableScreen.kt
@@ -1,0 +1,27 @@
+package de.lukasneugebauer.nextcloudcookbook.core.presentation.error
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import de.lukasneugebauer.nextcloudcookbook.R
+import de.lukasneugebauer.nextcloudcookbook.core.presentation.ui.theme.NextcloudCookbookTheme
+import de.lukasneugebauer.nextcloudcookbook.core.util.UiText
+
+@Composable
+fun ServerUnreachableScreen(onRetryClick: () -> Unit) {
+    AbstractErrorScreen(
+        uiText = UiText.StringResource(R.string.error_server_unreachable_description),
+        icon = Icons.Default.CloudOff,
+        iconContentDescription = UiText.StringResource(R.string.error_server_unreachable),
+        onRetryClick = onRetryClick,
+    )
+}
+
+@Composable
+@Preview
+private fun ServerUnreachableScreenPreview() {
+    NextcloudCookbookTheme {
+        ServerUnreachableScreen(onRetryClick = {})
+    }
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/presentation/error/ServerUnreachableScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/presentation/error/ServerUnreachableScreen.kt
@@ -13,7 +13,6 @@ fun ServerUnreachableScreen(onRetryClick: () -> Unit) {
     AbstractErrorScreen(
         uiText = UiText.StringResource(R.string.error_server_unreachable_description),
         icon = Icons.Default.CloudOff,
-        iconContentDescription = UiText.StringResource(R.string.error_server_unreachable),
         onRetryClick = onRetryClick,
     )
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/Resource.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/Resource.kt
@@ -13,5 +13,6 @@ sealed class Resource<T>(
     class Error<T>(
         message: UiText,
         data: T? = null,
+        val isAuthError: Boolean = false,
     ) : Resource<T>(data, message)
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/state/HomeScreenState.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/state/HomeScreenState.kt
@@ -13,4 +13,6 @@ sealed interface HomeScreenState {
     data class Error(
         val uiText: UiText,
     ) : HomeScreenState
+
+    object ServerUnreachable : HomeScreenState
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
@@ -25,7 +25,10 @@ import javax.inject.Singleton
 import javax.net.ssl.SSLHandshakeException
 
 sealed class HomeScreenDataFetchResult {
-    data class Success(val data: List<HomeScreenDataResult>) : HomeScreenDataFetchResult()
+    data class Success(
+        val data: List<HomeScreenDataResult>,
+    ) : HomeScreenDataFetchResult()
+
     object NetworkError : HomeScreenDataFetchResult()
 }
 
@@ -128,12 +131,11 @@ class GetHomeScreenDataUseCase
             }
         }
 
-        private fun isNetworkError(e: Exception): Boolean {
-            return e is SocketTimeoutException ||
+        private fun isNetworkError(e: Exception): Boolean =
+            e is SocketTimeoutException ||
                 e is UnknownHostException ||
                 e is SSLHandshakeException ||
                 e.cause is SocketTimeoutException ||
                 e.cause is UnknownHostException ||
                 e.cause is SSLHandshakeException
-        }
     }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/usecase/GetHomeScreenDataUseCase.kt
@@ -2,6 +2,7 @@ package de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase
 
 import de.lukasneugebauer.nextcloudcookbook.R
 import de.lukasneugebauer.nextcloudcookbook.core.data.PreferencesManager
+import de.lukasneugebauer.nextcloudcookbook.core.domain.NetworkErrorException
 import de.lukasneugebauer.nextcloudcookbook.core.domain.model.RecipeOfTheDay
 import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.DEFAULT_RECIPE_OF_THE_DAY_ID
 import de.lukasneugebauer.nextcloudcookbook.core.util.IoDispatcher
@@ -16,21 +17,12 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.mobilenativefoundation.store.store5.impl.extensions.get
-import timber.log.Timber
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.net.ssl.SSLHandshakeException
-
-sealed class HomeScreenDataFetchResult {
-    data class Success(
-        val data: List<HomeScreenDataResult>,
-    ) : HomeScreenDataFetchResult()
-
-    object NetworkError : HomeScreenDataFetchResult()
-}
 
 @Singleton
 class GetHomeScreenDataUseCase
@@ -43,19 +35,18 @@ class GetHomeScreenDataUseCase
         private val recipePreviewsStore: RecipePreviewsStore,
         private val recipeStore: RecipeStore,
     ) {
-        suspend operator fun invoke(): HomeScreenDataFetchResult {
-            val currentDate =
-                LocalDateTime
-                    .now()
-                    .withHour(0)
-                    .withMinute(0)
-                    .withSecond(0)
-            val homeScreenData = mutableListOf<HomeScreenDataResult>()
-            var recipeOfTheDay = preferencesManager.preferencesFlow.map { it.recipeOfTheDay }.first()
-            var networkErrorOccurred = false
+        suspend operator fun invoke(): List<HomeScreenDataResult> {
+            try {
+                val currentDate =
+                    LocalDateTime
+                        .now()
+                        .withHour(0)
+                        .withMinute(0)
+                        .withSecond(0)
+                val homeScreenData = mutableListOf<HomeScreenDataResult>()
+                var recipeOfTheDay = preferencesManager.preferencesFlow.map { it.recipeOfTheDay }.first()
 
-            if (recipeOfTheDay.id == DEFAULT_RECIPE_OF_THE_DAY_ID || recipeOfTheDay.updatedAt.isBefore(currentDate)) {
-                try {
+                if (recipeOfTheDay.id == DEFAULT_RECIPE_OF_THE_DAY_ID || recipeOfTheDay.updatedAt.isBefore(currentDate)) {
                     val newRecipeOfTheDayId =
                         recipePreviewsStore
                             .get(Unit)
@@ -70,34 +61,20 @@ class GetHomeScreenDataUseCase
                             updatedAt = LocalDateTime.now(),
                         )
                     preferencesManager.updateRecipeOfTheDay(recipeOfTheDay)
-                } catch (e: Exception) {
-                    Timber.e(e.stackTraceToString())
-                    if (isNetworkError(e)) {
-                        networkErrorOccurred = true
-                    }
                 }
-            }
 
-            // FIXME: 25.12.21 Get different recipe of the day if api returns 404 error.
-            //  E.g. after deleting recipe of the day.
-            withContext(ioDispatcher) {
-                try {
+                // FIXME: 25.12.21 Get different recipe of the day if api returns 404 error.
+                //  E.g. after deleting recipe of the day.
+                withContext(ioDispatcher) {
                     val result =
                         HomeScreenDataResult.Single(
                             R.string.home_recommendation,
                             recipeStore.get(recipeOfTheDay.id).toRecipe(),
                         )
                     homeScreenData.add(result)
-                } catch (e: Exception) {
-                    Timber.e(e.stackTraceToString())
-                    if (isNetworkError(e)) {
-                        networkErrorOccurred = true
-                    }
                 }
-            }
 
-            withContext(ioDispatcher) {
-                try {
+                withContext(ioDispatcher) {
                     categoriesStore
                         .get(Unit)
                         .sortedByDescending { it.recipeCount }
@@ -116,18 +93,14 @@ class GetHomeScreenDataUseCase
                                 homeScreenData.add(result)
                             }
                         }
-                } catch (e: Exception) {
-                    Timber.e(e.stackTraceToString())
-                    if (isNetworkError(e)) {
-                        networkErrorOccurred = true
-                    }
                 }
-            }
 
-            return if (homeScreenData.isEmpty() && networkErrorOccurred) {
-                HomeScreenDataFetchResult.NetworkError
-            } else {
-                HomeScreenDataFetchResult.Success(homeScreenData.toList())
+                return homeScreenData.toList()
+            } catch (e: Exception) {
+                if (isNetworkError(e)) {
+                    throw NetworkErrorException(e)
+                }
+                throw e
             }
         }
 

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeScreen.kt
@@ -54,6 +54,7 @@ import de.lukasneugebauer.nextcloudcookbook.core.presentation.components.Loader
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.components.RowContainer
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.components.RowContent
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.error.NotFoundScreen
+import de.lukasneugebauer.nextcloudcookbook.core.presentation.error.ServerUnreachableScreen
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.error.UnknownErrorScreen
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.ui.theme.NextcloudCookbookTheme
 import de.lukasneugebauer.nextcloudcookbook.core.util.AspectRatio
@@ -89,6 +90,7 @@ fun AnimatedVisibilityScope.HomeScreen(
                 ),
             )
         },
+        onRetryClick = { viewModel.retry() },
     )
 }
 
@@ -121,6 +123,7 @@ fun HomeScreen(
     onSettingsIconClick: () -> Unit,
     onHeadlineClick: (categoryName: String) -> Unit,
     onRecipeClick: (recipeId: String) -> Unit,
+    onRetryClick: () -> Unit = {},
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
     val lazyListState = rememberLazyListState()
@@ -200,6 +203,7 @@ fun HomeScreen(
                 }
             }
             is HomeScreenState.Error -> UnknownErrorScreen()
+            HomeScreenState.ServerUnreachable -> ServerUnreachableScreen(onRetryClick = onRetryClick)
         }
     }
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.HomeScreenState
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.GetHomeScreenDataUseCase
+import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.HomeScreenDataFetchResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -15,14 +16,30 @@ import javax.inject.Inject
 class HomeViewModel
     @Inject
     constructor(
-        getHomeScreenDataUseCase: GetHomeScreenDataUseCase,
+        private val getHomeScreenDataUseCase: GetHomeScreenDataUseCase,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<HomeScreenState>(HomeScreenState.Initial)
         val uiState = _uiState.asStateFlow()
 
         init {
+            loadData()
+        }
+
+        fun retry() {
+            _uiState.update { HomeScreenState.Initial }
+            loadData()
+        }
+
+        private fun loadData() {
             viewModelScope.launch {
-                _uiState.update { HomeScreenState.Loaded(getHomeScreenDataUseCase()) }
+                when (val result = getHomeScreenDataUseCase()) {
+                    is HomeScreenDataFetchResult.Success -> {
+                        _uiState.update { HomeScreenState.Loaded(result.data) }
+                    }
+                    is HomeScreenDataFetchResult.NetworkError -> {
+                        _uiState.update { HomeScreenState.ServerUnreachable }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.HomeScreenState
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.GetHomeScreenDataUseCase
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.HomeScreenDataFetchResult
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -20,6 +21,7 @@ class HomeViewModel
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<HomeScreenState>(HomeScreenState.Initial)
         val uiState = _uiState.asStateFlow()
+        private var loadJob: Job? = null
 
         init {
             loadData()
@@ -31,7 +33,8 @@ class HomeViewModel
         }
 
         private fun loadData() {
-            viewModelScope.launch {
+            loadJob?.cancel()
+            loadJob = viewModelScope.launch {
                 when (val result = getHomeScreenDataUseCase()) {
                     is HomeScreenDataFetchResult.Success -> {
                         _uiState.update { HomeScreenState.Loaded(result.data) }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
@@ -3,14 +3,15 @@ package de.lukasneugebauer.nextcloudcookbook.recipe.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lukasneugebauer.nextcloudcookbook.core.domain.NetworkErrorException
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.HomeScreenState
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.GetHomeScreenDataUseCase
-import de.lukasneugebauer.nextcloudcookbook.recipe.domain.usecase.HomeScreenDataFetchResult
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,12 +37,16 @@ class HomeViewModel
             loadJob?.cancel()
             loadJob =
                 viewModelScope.launch {
-                    when (val result = getHomeScreenDataUseCase()) {
-                        is HomeScreenDataFetchResult.Success -> {
-                            _uiState.update { HomeScreenState.Loaded(result.data) }
-                        }
-                        is HomeScreenDataFetchResult.NetworkError -> {
-                            _uiState.update { HomeScreenState.ServerUnreachable }
+                    try {
+                        val data = getHomeScreenDataUseCase()
+                        _uiState.update { HomeScreenState.Loaded(data) }
+                    } catch (e: NetworkErrorException) {
+                        Timber.e(e.stackTraceToString())
+                        _uiState.update { HomeScreenState.ServerUnreachable }
+                    } catch (e: Exception) {
+                        Timber.e(e.stackTraceToString())
+                        _uiState.update {
+                            HomeScreenState.Error(UiText.StringResource(R.string.error_unknown))
                         }
                     }
                 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/home/HomeViewModel.kt
@@ -34,15 +34,16 @@ class HomeViewModel
 
         private fun loadData() {
             loadJob?.cancel()
-            loadJob = viewModelScope.launch {
-                when (val result = getHomeScreenDataUseCase()) {
-                    is HomeScreenDataFetchResult.Success -> {
-                        _uiState.update { HomeScreenState.Loaded(result.data) }
-                    }
-                    is HomeScreenDataFetchResult.NetworkError -> {
-                        _uiState.update { HomeScreenState.ServerUnreachable }
+            loadJob =
+                viewModelScope.launch {
+                    when (val result = getHomeScreenDataUseCase()) {
+                        is HomeScreenDataFetchResult.Success -> {
+                            _uiState.update { HomeScreenState.Loaded(result.data) }
+                        }
+                        is HomeScreenDataFetchResult.NetworkError -> {
+                            _uiState.update { HomeScreenState.ServerUnreachable }
+                        }
                     }
                 }
-            }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="error_timeout">Timeout error</string>
     <string name="error_unknown_host">Unknown host</string>
     <string name="error_unknown">An unknown error occurred</string>
+    <string name="error_server_unreachable">Server unreachable</string>
+    <string name="error_server_unreachable_description">Could not connect to your Nextcloud server. Please check your network connection and try again.</string>
     <string name="home_recommendation">Recommendation</string>
     <string name="info_headline">Learn more</string>
     <string name="login">Sign in</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,6 @@
     <string name="error_timeout">Timeout error</string>
     <string name="error_unknown_host">Unknown host</string>
     <string name="error_unknown">An unknown error occurred</string>
-    <string name="error_server_unreachable">Server unreachable</string>
     <string name="error_server_unreachable_description">Could not connect to your Nextcloud server. Please check your network connection and try again.</string>
     <string name="home_recommendation">Recommendation</string>
     <string name="info_headline">Learn more</string>


### PR DESCRIPTION
Before this change the user would receive an error message and a forced logout from the Cookbook app if the Nextcloud server was unreachable.

In my case Nextcloud is only reachable through a VPN. This meant I would be logged out of the Cookbook app whenever I wasn't connected through the VPN - which could be quite often.

After this change, the app differentiate between unreachable host and wrong credentials. If the former, we simply show a retry button to the user (See screenshot). After connecting to the VPN, you can simply press 'retry' to reconnect.

As I have zero knowledge of Kotlin, I've been assisted by Claude Code to develop the fix. I've been using a build with these changes for the past month without any problems.

This pull request should solve the still-open [Issue #71](https://github.com/lneugebauer/nextcloud-cookbook/issues/71)

<img width="270" height="585" alt="Screenshot of Cookbook app with Retry button" src="https://github.com/user-attachments/assets/dd300b73-cb03-49b4-bd48-cf47b9abbd8a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server unreachable screen with retry functionality
  * Improved network error detection and handling

* **Bug Fixes**
  * Credentials no longer cleared during network connectivity issues
  * Enhanced offline access support
  * Better distinction between authentication errors and network failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->