### PR TITLE
fix: update category view on receipt update

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/di/RecipeModule.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/di/RecipeModule.kt
@@ -80,6 +80,7 @@ object RecipeModule {
         recipesByCategoryStore: RecipePreviewsByCategoryStore,
         recipePreviewsStore: RecipePreviewsStore,
         recipeStore: RecipeStore,
+        categoriesStore: CategoriesStore,
     ): RecipeRepository =
         RecipeRepositoryImpl(
             apiProvider,
@@ -88,6 +89,7 @@ object RecipeModule {
             recipesByCategoryStore,
             recipePreviewsStore,
             recipeStore,
+            categoriesStore,
         )
 
     @Provides

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/data/repository/RecipeRepositoryImpl.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/data/repository/RecipeRepositoryImpl.kt
@@ -10,6 +10,7 @@ import de.lukasneugebauer.nextcloudcookbook.core.util.IoDispatcher
 import de.lukasneugebauer.nextcloudcookbook.core.util.Resource
 import de.lukasneugebauer.nextcloudcookbook.core.util.SimpleResource
 import de.lukasneugebauer.nextcloudcookbook.core.util.UiText
+import de.lukasneugebauer.nextcloudcookbook.di.CategoriesStore
 import de.lukasneugebauer.nextcloudcookbook.di.RecipePreviewsByCategoryStore
 import de.lukasneugebauer.nextcloudcookbook.di.RecipePreviewsStore
 import de.lukasneugebauer.nextcloudcookbook.di.RecipeStore
@@ -38,6 +39,7 @@ class RecipeRepositoryImpl
         private val recipePreviewsByCategoryStore: RecipePreviewsByCategoryStore,
         private val recipePreviewsStore: RecipePreviewsStore,
         private val recipeStore: RecipeStore,
+        private val categoriesStore: CategoriesStore,
     ) : BaseRepository(),
         RecipeRepository {
         override fun getRecipePreviewsFlow(): Flow<StoreReadResponse<List<RecipePreviewDto>>> =
@@ -98,6 +100,12 @@ class RecipeRepositoryImpl
                     }
 
                     refreshCaches(id = recipe.id, categoryName = recipe.recipeCategory)
+
+                    if (currentRecipe.recipeCategory != recipe.recipeCategory) {
+                        recipePreviewsByCategoryStore.fresh(currentRecipe.recipeCategory)
+                        categoriesStore.fresh(Unit)
+                    }
+
                     Resource.Success(Unit)
                 } catch (e: Exception) {
                     handleResponseError(e.fillInStackTrace())
@@ -119,7 +127,10 @@ class RecipeRepositoryImpl
                         refreshCaches(id = id, categoryName = categoryName, deleted = true)
                         Resource.Success(Unit)
                     }
-                    is NetworkResponse.Error -> handleResponseError(response.error, response.body?.msg)
+
+                    is NetworkResponse.Error -> {
+                        handleResponseError(response.error, response.body?.msg)
+                    }
                 }
             }
         }
@@ -135,7 +146,10 @@ class RecipeRepositoryImpl
                         refreshCaches(id = response.body.id, categoryName = response.body.recipeCategory)
                         Resource.Success(response.body)
                     }
-                    is NetworkResponse.Error -> handleResponseError(response.error, response.body?.msg)
+
+                    is NetworkResponse.Error -> {
+                        handleResponseError(response.error, response.body?.msg)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before this change I had to restart the App after changing the category of a receipt, to update the categories view.
You can reproduce it when you edit a receipt, change it's category and search for it in the category overview. This view only refresh after App restart.

To fix this, i refresh the stores of the categories and receipt categories view.
I thought about defining a UseCase, instead of direct access of the categoriesStore, but decided to go the direct way, for better readability

The brackets were added by my ktlint plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency when updating recipe categories—category information now properly refreshes when a recipe's category is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->