### PR TITLE
Log login WebView load errors

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
@@ -2,12 +2,12 @@ package de.lukasneugebauer.nextcloudcookbook.auth.domain
 
 import android.annotation.SuppressLint
 import android.net.http.SslError
-import android.util.Log
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import timber.log.Timber
 
 class WebViewClient(
     private val allowSelfSignedCertificates: Boolean,
@@ -37,18 +37,20 @@ class WebViewClient(
         error: WebResourceError?,
     ) {
         if (request != null && request.isForMainFrame) {
+            val sanitizedUrl =
+                request.url
+                    .buildUpon()
+                    .clearQuery()
+                    .fragment(null)
+                    .build()
             val errorCode = error?.errorCode ?: ERROR_UNKNOWN
             val description = error?.description
-            Log.w(
-                TAG,
-                "Login WebView load error $errorCode: $description @ ${request.url}",
-            )
+            Timber.w("Login WebView load error $errorCode: $description @ $sanitizedUrl")
             onMainFrameError(errorCode, description)
         }
     }
 
     private companion object {
-        private const val TAG = "AuthWebViewClient"
         private const val ERROR_UNKNOWN = -1
     }
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
@@ -11,6 +11,7 @@ import android.webkit.WebViewClient
 
 class WebViewClient(
     private val allowSelfSignedCertificates: Boolean,
+    private val onMainFrameError: (errorCode: Int, description: CharSequence?) -> Unit = { _, _ -> },
 ) : WebViewClient() {
     override fun shouldOverrideUrlLoading(
         view: WebView?,
@@ -36,14 +37,18 @@ class WebViewClient(
         error: WebResourceError?,
     ) {
         if (request != null && request.isForMainFrame) {
+            val errorCode = error?.errorCode ?: ERROR_UNKNOWN
+            val description = error?.description
             Log.w(
                 TAG,
-                "Login WebView load error ${error?.errorCode}: ${error?.description} @ ${request.url}",
+                "Login WebView load error $errorCode: $description @ ${request.url}",
             )
+            onMainFrameError(errorCode, description)
         }
     }
 
     private companion object {
         private const val TAG = "AuthWebViewClient"
+        private const val ERROR_UNKNOWN = -1
     }
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/domain/WebViewClient.kt
@@ -2,7 +2,9 @@ package de.lukasneugebauer.nextcloudcookbook.auth.domain
 
 import android.annotation.SuppressLint
 import android.net.http.SslError
+import android.util.Log
 import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -26,5 +28,22 @@ class WebViewClient(
         } else {
             handler?.cancel()
         }
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?,
+    ) {
+        if (request != null && request.isForMainFrame) {
+            Log.w(
+                TAG,
+                "Login WebView load error ${error?.errorCode}: ${error?.description} @ ${request.url}",
+            )
+        }
+    }
+
+    private companion object {
+        private const val TAG = "AuthWebViewClient"
     }
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginScreen.kt
@@ -69,12 +69,17 @@ fun AnimatedVisibilityScope.WebViewLoginScreen(
                 WebViewLoginLayout(
                     url = webViewUrl,
                     allowSelfSignedCertificates = allowSelfSignedCertificates,
+                    onMainFrameError = viewModel::onWebViewLoadError,
                     modifier = Modifier.padding(innerPadding),
                 )
             }
             is WebViewScreenState.Error -> {
                 val message = (uiState as WebViewScreenState.Error).uiText
-                AbstractErrorScreen(uiText = message, modifier = Modifier.padding(innerPadding))
+                AbstractErrorScreen(
+                    uiText = message,
+                    modifier = Modifier.padding(innerPadding),
+                    onRetryClick = { viewModel.retry() },
+                )
             }
         }
     }
@@ -86,12 +91,17 @@ private fun WebViewLoginLayout(
     url: Uri,
     allowSelfSignedCertificates: Boolean,
     modifier: Modifier = Modifier,
+    onMainFrameError: (Int, CharSequence?) -> Unit = { _, _ -> },
 ) {
     AndroidView(
         factory = {
             WebView(it).apply {
                 settings.javaScriptEnabled = true
-                webViewClient = WebViewClient(allowSelfSignedCertificates = allowSelfSignedCertificates)
+                webViewClient =
+                    WebViewClient(
+                        allowSelfSignedCertificates = allowSelfSignedCertificates,
+                        onMainFrameError = onMainFrameError,
+                    )
                 loadUrl(url.toString())
             }
         },

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/auth/presentation/webview/WebViewLoginViewModel.kt
@@ -37,14 +37,34 @@ class WebViewLoginViewModel
         private val _uiState = MutableStateFlow<WebViewScreenState>(WebViewScreenState.Initial)
         val uiState = _uiState.asStateFlow()
 
+        private val initialUrl: String? = savedStateHandle["url"]
+
         init {
-            val url: String? = savedStateHandle["url"]
+            val url = initialUrl
             if (url != null) {
                 getLoginEndpoint(url = url)
                 observeAuthorizationStatus()
             } else {
                 _uiState.update { WebViewScreenState.Error(uiText = UiText.StringResource(R.string.error_invalid_url)) }
             }
+        }
+
+        fun onWebViewLoadError(
+            errorCode: Int,
+            description: CharSequence?,
+        ) {
+            Timber.w("Login WebView reported error $errorCode: $description")
+            _uiState.update {
+                WebViewScreenState.Error(
+                    uiText = UiText.StringResource(R.string.error_webview_load_failed),
+                )
+            }
+        }
+
+        fun retry() {
+            val url = initialUrl ?: return
+            _uiState.update { WebViewScreenState.Initial }
+            getLoginEndpoint(url = url)
         }
 
         private fun getLoginEndpoint(url: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_timeout">Timeout error</string>
     <string name="error_unknown_host">Unknown host</string>
     <string name="error_unknown">An unknown error occurred</string>
+    <string name="error_webview_load_failed">The login page couldn\'t load. Check your connection and try again.</string>
     <string name="home_recommendation">Recommendation</string>
     <string name="info_headline">Learn more</string>
     <string name="login">Sign in</string>


### PR DESCRIPTION
Closes #191

### What this does

Adds an `onReceivedError(view, request, error)` override to the custom `WebViewClient` in `auth/domain/WebViewClient.kt`. It logs the error code, description and failing URL via `Log.w` when the failure is for the main frame, so sub-resource failures do not flood the log.

Also adds a small private `companion object { TAG }` because the class did not have one yet.

No behaviour change. No UI change. No new dependencies.

### Why

Right now a failed login load is invisible from logcat. Users reporting "blank login page" have to be asked to capture a Chrome inspect session or get walked through reproducing it. This single override gives the maintainer (or a curious user) an immediate error line to point at instead.

`minSdk` is 25, so the API 23+ signature is safe to use as the only override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show a dedicated error screen with a Retry action when the login WebView fails to load.
  * Added a user-facing message suggesting to check the connection and try again.

* **Bug Fixes**
  * Detect, log, and surface WebView main-frame load failures to the UI so users can recover via Retry.
  * Retry restores initial login flow and attempts loading again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->