### PR TITLE
feat: add ingredients to a Nextcloud Tasks shopping list

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/PreferencesManager.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/data/PreferencesManager.kt
@@ -21,6 +21,7 @@ import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.DEFAULT_RECIPE_O
 import de.lukasneugebauer.nextcloudcookbook.core.util.Constants.IS_SHOW_INGREDIENT_SYNTAX_INDICATOR_DEFAULT
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.STAY_AWAKE_DEFAULT
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.STAY_AWAKE_KEY
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -93,6 +94,8 @@ class PreferencesManager
             val RECIPE_OF_THE_DAY_UPDATED_AT = longPreferencesKey("recipe_of_the_day_updated_at")
             val ALLOW_SELF_SIGNED_CERTIFICATES = booleanPreferencesKey("allow_self_signed_certificates")
             val IS_SHOW_INGREDIENT_SYNTAX_INDICATOR = booleanPreferencesKey("is_show_ingredient_syntax_indicator")
+            val SHOPPING_LIST_URL = stringPreferencesKey("shopping_list_url")
+            val SHOPPING_LIST_NAME = stringPreferencesKey("shopping_list_name")
         }
 
         val preferencesFlow =
@@ -120,6 +123,14 @@ class PreferencesManager
                             ?: DEFAULT_RECIPE_IMAGE_UPLOAD_FOLDER
                     val allowSelfSignedCertificates =
                         preferences[PreferencesKeys.ALLOW_SELF_SIGNED_CERTIFICATES] ?: ALLOW_SELF_SIGNED_CERTIFICATES_DEFAULT
+                    val shoppingListUrl = preferences[PreferencesKeys.SHOPPING_LIST_URL] ?: ""
+                    val shoppingListName = preferences[PreferencesKeys.SHOPPING_LIST_NAME] ?: ""
+                    val shoppingList =
+                        if (shoppingListUrl.isNotBlank()) {
+                            TaskList(url = shoppingListUrl, displayName = shoppingListName)
+                        } else {
+                            null
+                        }
 
                     de.lukasneugebauer.nextcloudcookbook.core.domain.model.Preferences(
                         isShowIngredientSyntaxIndicator = isShowIngredientSyntaxIndicator,
@@ -143,6 +154,7 @@ class PreferencesManager
                             ),
                         allowSelfSignedCertificates = allowSelfSignedCertificates,
                         recipeImageUploadFolder = recipeImageUploadFolder,
+                        shoppingList = shoppingList,
                     )
                 }
 
@@ -181,6 +193,12 @@ class PreferencesManager
         suspend fun updateRecipeImageUploadFolder(recipeImageUploadFolder: String) =
             context.dataStore54.edit { preferences ->
                 preferences[PreferencesKeys.RECIPE_IMAGE_UPLOAD_FOLDER] = recipeImageUploadFolder
+            }
+
+        suspend fun updateShoppingList(shoppingList: TaskList) =
+            context.dataStore54.edit { preferences ->
+                preferences[PreferencesKeys.SHOPPING_LIST_URL] = shoppingList.url
+                preferences[PreferencesKeys.SHOPPING_LIST_NAME] = shoppingList.displayName
             }
 
         suspend fun clearPreferences() {

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/model/Preferences.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/domain/model/Preferences.kt
@@ -2,6 +2,7 @@ package de.lukasneugebauer.nextcloudcookbook.core.domain.model
 
 import androidx.compose.runtime.compositionLocalOf
 import de.lukasneugebauer.nextcloudcookbook.core.util.Constants
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
 
 data class Preferences(
     val isShowIngredientSyntaxIndicator: Boolean,
@@ -9,6 +10,7 @@ data class Preferences(
     val recipeOfTheDay: RecipeOfTheDay,
     val allowSelfSignedCertificates: Boolean,
     val recipeImageUploadFolder: String = Constants.DEFAULT_RECIPE_IMAGE_UPLOAD_FOLDER,
+    val shoppingList: TaskList? = null,
 )
 
 val LocalPreferences = compositionLocalOf<Preferences?> { null }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/di/TasksModule.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/di/TasksModule.kt
@@ -1,0 +1,26 @@
+package de.lukasneugebauer.nextcloudcookbook.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import de.lukasneugebauer.nextcloudcookbook.core.data.PreferencesManager
+import de.lukasneugebauer.nextcloudcookbook.core.util.IoDispatcher
+import de.lukasneugebauer.nextcloudcookbook.core.util.OkHttpClientProvider
+import de.lukasneugebauer.nextcloudcookbook.tasks.data.remote.CalDavXmlParser
+import de.lukasneugebauer.nextcloudcookbook.tasks.data.repository.TasksRepositoryImpl
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.repository.TasksRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TasksModule {
+    @Provides
+    @Singleton
+    fun provideTasksRepository(
+        clientProvider: OkHttpClientProvider,
+        preferencesManager: PreferencesManager,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    ): TasksRepository = TasksRepositoryImpl(clientProvider, preferencesManager, ioDispatcher, CalDavXmlParser())
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/state/RecipeDetailState.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/domain/state/RecipeDetailState.kt
@@ -14,4 +14,17 @@ data class RecipeDetailState(
     val loading: Boolean = true,
     val isShowIngredientSyntaxIndicator: Boolean = IS_SHOW_INGREDIENT_SYNTAX_INDICATOR_DEFAULT,
     val showFullScreenImage: Boolean = false,
+    val isShoppingListConfigured: Boolean = false,
+    val showShoppingListDialog: Boolean = false,
+    val shoppingListResult: ShoppingListResult? = null,
 )
+
+sealed interface ShoppingListResult {
+    data class Success(
+        val count: Int,
+    ) : ShoppingListResult
+
+    data class Error(
+        val message: UiText,
+    ) : ShoppingListResult
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/detail/RecipeDetailScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/detail/RecipeDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.Report
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.AddShoppingCart
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Remove
@@ -120,7 +121,9 @@ import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Instruction
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Nutrition
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Recipe
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Tool
+import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.ShoppingListResult
 import de.lukasneugebauer.nextcloudcookbook.recipe.util.emptyRecipe
+import de.lukasneugebauer.nextcloudcookbook.tasks.presentation.AddToShoppingListDialog
 import kotlinx.coroutines.launch
 import java.time.Duration
 
@@ -157,6 +160,35 @@ fun AnimatedVisibilityScope.RecipeDetailScreen(
             contentDescription = recipe.name,
             onDismiss = { viewModel.hideFullScreenImage() },
         )
+    }
+
+    if (state.showShoppingListDialog) {
+        AddToShoppingListDialog(
+            ingredients =
+                state.calculatedIngredients
+                    .ifEmpty { recipe.ingredients.map { CalculatedIngredient(it.value, it.hasCorrectSyntax) } }
+                    .map { it.ingredient }
+                    .filterNot { it.startsWith("##") },
+            onConfirm = { viewModel.addIngredientsToShoppingList(it) },
+            onDismiss = { viewModel.hideShoppingListDialog() },
+        )
+    }
+
+    state.shoppingListResult?.let { result ->
+        val message =
+            when (result) {
+                is ShoppingListResult.Success ->
+                    context.resources.getQuantityString(
+                        R.plurals.shopping_list_ingredients_added,
+                        result.count,
+                        result.count,
+                    )
+                is ShoppingListResult.Error -> result.message.asString()
+            }
+        LaunchedEffect(result) {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            viewModel.clearShoppingListResult()
+        }
     }
 
     RecipeDetailLayout(
@@ -211,6 +243,9 @@ fun AnimatedVisibilityScope.RecipeDetailScreen(
             viewModel.resetYield()
         },
         isShowIngredientSyntaxIndicator = state.isShowIngredientSyntaxIndicator,
+        onAddToShoppingListClick = {
+            viewModel.onAddToShoppingListClick()
+        },
     )
 }
 
@@ -347,6 +382,7 @@ fun RecipeDetailLayout(
     onKeywordClick: (keyword: String) -> Unit,
     onResetYield: () -> Unit,
     isShowIngredientSyntaxIndicator: Boolean,
+    onAddToShoppingListClick: () -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
@@ -415,6 +451,7 @@ fun RecipeDetailLayout(
                         currentYield,
                         recipe.yield != currentYield,
                         isShowIngredientSyntaxIndicator,
+                        onAddToShoppingListClick,
                     )
                 }
                 if (recipe.nutrition != null) {
@@ -593,6 +630,7 @@ private fun Ingredients(
     currentYield: Int,
     showResetButton: Boolean,
     isShowIngredientSyntaxIndicator: Boolean,
+    onAddToShoppingListClick: () -> Unit,
 ) {
     val clipboard = LocalClipboard.current
     val context = LocalContext.current
@@ -638,6 +676,12 @@ private fun Ingredients(
             Icon(
                 imageVector = Icons.Outlined.ContentCopy,
                 contentDescription = stringResource(R.string.recipe_ingredients_copy),
+            )
+        }
+        IconButton(onClick = onAddToShoppingListClick) {
+            Icon(
+                imageVector = Icons.Outlined.AddShoppingCart,
+                contentDescription = stringResource(R.string.recipe_ingredients_add_to_shopping_list),
             )
         }
     }
@@ -980,6 +1024,7 @@ private fun IngredientsPreview() {
                 currentYield = 2,
                 showResetButton = false,
                 isShowIngredientSyntaxIndicator = true,
+                onAddToShoppingListClick = {},
             )
         }
     }
@@ -1066,6 +1111,7 @@ private fun RecipeDetailLayoutPreview() {
             onKeywordClick = {},
             onResetYield = {},
             isShowIngredientSyntaxIndicator = true,
+            onAddToShoppingListClick = {},
         )
     }
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/detail/RecipeDetailViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/recipe/presentation/detail/RecipeDetailViewModel.kt
@@ -16,11 +16,13 @@ import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Ingredient
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.model.Recipe
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.repository.RecipeRepository
 import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.RecipeDetailState
+import de.lukasneugebauer.nextcloudcookbook.recipe.domain.state.ShoppingListResult
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.repository.TasksRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -35,6 +37,7 @@ class RecipeDetailViewModel
         private val recipeFormatter: RecipeFormatter,
         private val recipeRepository: RecipeRepository,
         savedStateHandle: SavedStateHandle,
+        private val tasksRepository: TasksRepository,
         private val yieldCalculator: YieldCalculator,
     ) : ViewModel() {
         private val _state = MutableStateFlow(RecipeDetailState())
@@ -55,17 +58,19 @@ class RecipeDetailViewModel
         private fun getRecipe(id: String) {
             _state.value = _state.value.copy(loading = true)
             combine(
-                preferencesManager.preferencesFlow.map { it.isShowIngredientSyntaxIndicator },
+                preferencesManager.preferencesFlow,
                 recipeRepository.getRecipeFlow(id),
                 recipeRepository.getRecipePreviewsFlow(),
-            ) { isShowIngredientSyntaxIndicator, recipeResponse, recipePreviewsResponse ->
+            ) { preferences, recipeResponse, recipePreviewsResponse ->
                 val recipePreviewDtos =
                     when (recipePreviewsResponse) {
                         is StoreReadResponse.Data -> recipePreviewsResponse.dataOrNull()
                         else -> null
                     }
-                Triple(isShowIngredientSyntaxIndicator, recipeResponse, recipePreviewDtos)
-            }.onEach { (isShowIngredientSyntaxIndicator, recipeResponse, recipePreviewDtos) ->
+                Triple(preferences, recipeResponse, recipePreviewDtos)
+            }.onEach { (preferences, recipeResponse, recipePreviewDtos) ->
+                val isShowIngredientSyntaxIndicator = preferences.isShowIngredientSyntaxIndicator
+                _state.update { it.copy(isShoppingListConfigured = preferences.shoppingList != null) }
                 when (recipeResponse) {
                     is StoreReadResponse.Loading ->
                         _state.value =
@@ -186,6 +191,48 @@ class RecipeDetailViewModel
 
         fun hideFullScreenImage() {
             _state.value = _state.value.copy(showFullScreenImage = false)
+        }
+
+        fun onAddToShoppingListClick() {
+            if (_state.value.isShoppingListConfigured) {
+                _state.update { it.copy(showShoppingListDialog = true) }
+            } else {
+                _state.update {
+                    it.copy(
+                        shoppingListResult =
+                            ShoppingListResult.Error(UiText.StringResource(R.string.shopping_list_not_configured)),
+                    )
+                }
+            }
+        }
+
+        fun hideShoppingListDialog() {
+            _state.update { it.copy(showShoppingListDialog = false) }
+        }
+
+        fun addIngredientsToShoppingList(entries: List<String>) {
+            _state.update { it.copy(showShoppingListDialog = false) }
+            if (entries.isEmpty()) return
+            viewModelScope.launch {
+                val listUrl =
+                    preferencesManager.preferencesFlow
+                        .first()
+                        .shoppingList
+                        ?.url ?: return@launch
+                val result =
+                    when (val resource = tasksRepository.createTasks(listUrl, entries)) {
+                        is Resource.Success -> ShoppingListResult.Success(resource.data ?: entries.size)
+                        is Resource.Error ->
+                            ShoppingListResult.Error(
+                                resource.message ?: UiText.StringResource(R.string.shopping_list_error_adding),
+                            )
+                    }
+                _state.update { it.copy(shoppingListResult = result) }
+            }
+        }
+
+        fun clearShoppingListResult() {
+            _state.update { it.copy(shoppingListResult = null) }
         }
 
         private fun enrichRecipeLinks(

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/domain/state/SettingsScreenState.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/domain/state/SettingsScreenState.kt
@@ -7,5 +7,6 @@ sealed interface SettingsScreenState {
         val isStayAwake: Boolean,
         val isShowRecipeSyntaxIndicator: Boolean,
         val recipeImageUploadFolder: String,
+        val shoppingListName: String? = null,
     ) : SettingsScreenState
 }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/domain/state/ShoppingListDialogState.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/domain/state/ShoppingListDialogState.kt
@@ -1,0 +1,19 @@
+package de.lukasneugebauer.nextcloudcookbook.settings.domain.state
+
+import de.lukasneugebauer.nextcloudcookbook.core.util.UiText
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
+
+sealed interface ShoppingListDialogState {
+    object Hidden : ShoppingListDialogState
+
+    object Loading : ShoppingListDialogState
+
+    data class Loaded(
+        val taskLists: List<TaskList>,
+        val selectedUrl: String? = null,
+    ) : ShoppingListDialogState
+
+    data class Error(
+        val message: UiText,
+    ) : ShoppingListDialogState
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/presentation/settings/SettingsScreen.kt
@@ -20,14 +20,19 @@ import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.LightMode
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Report
+import androidx.compose.material.icons.outlined.ShoppingCart
 import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -55,6 +60,7 @@ import de.lukasneugebauer.nextcloudcookbook.core.presentation.components.Loader
 import de.lukasneugebauer.nextcloudcookbook.core.presentation.ui.theme.NextcloudCookbookTheme
 import de.lukasneugebauer.nextcloudcookbook.core.util.openInBrowser
 import de.lukasneugebauer.nextcloudcookbook.settings.domain.state.SettingsScreenState
+import de.lukasneugebauer.nextcloudcookbook.settings.domain.state.ShoppingListDialogState
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.GITHUB_ISSUES_URL
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.GITHUB_SPONSOR_URL
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.GITHUB_URL
@@ -63,6 +69,7 @@ import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.LICE
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.PAYPAL_URL
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.PRIVACY_URL
 import de.lukasneugebauer.nextcloudcookbook.settings.util.SettingsConstants.WEBLATE_URL
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
 
 @Destination<MainGraph>
 @Composable
@@ -98,6 +105,10 @@ fun AnimatedVisibilityScope.SettingsScreen(
                     recipeImageUploadFolder = currentState.recipeImageUploadFolder,
                     onRecipeImageUploadFolderClick = {
                         navigator.navigate(RecipeImageUploadFolderScreenDestination)
+                    },
+                    shoppingListName = currentState.shoppingListName,
+                    onShoppingListClick = {
+                        viewModel.showShoppingListDialog()
                     },
                     onLogoutClick = {
                         viewModel.logout {
@@ -136,6 +147,13 @@ fun AnimatedVisibilityScope.SettingsScreen(
                         PAYPAL_URL.toUri().openInBrowser(context)
                     },
                 )
+
+                val shoppingListDialogState by viewModel.shoppingListDialogState.collectAsState()
+                ShoppingListSelectionDialog(
+                    state = shoppingListDialogState,
+                    onSelect = { viewModel.setShoppingList(it) },
+                    onDismiss = { viewModel.hideShoppingListDialog() },
+                )
             }
         }
     }
@@ -165,6 +183,8 @@ fun SettingsLayout(
     onShowRecipeSyntaxIndicatorChange: (Boolean) -> Unit,
     recipeImageUploadFolder: String,
     onRecipeImageUploadFolderClick: () -> Unit,
+    shoppingListName: String?,
+    onShoppingListClick: () -> Unit,
     onLogoutClick: () -> Unit,
     onPrivacyClick: () -> Unit,
     onLicenseClick: () -> Unit,
@@ -190,6 +210,8 @@ fun SettingsLayout(
             onShowRecipeSyntaxIndicatorChange = onShowRecipeSyntaxIndicatorChange,
             recipeImageUploadFolder = recipeImageUploadFolder,
             onRecipeImageUploadFolderClick = onRecipeImageUploadFolderClick,
+            shoppingListName = shoppingListName,
+            onShoppingListClick = onShoppingListClick,
         )
         Spacer(modifier = Modifier.size(size = dimensionResource(R.dimen.padding_m)))
         SettingsGroupAccount(onLogoutClick = onLogoutClick)
@@ -225,6 +247,8 @@ fun ColumnScope.SettingsGroupGeneral(
     onShowRecipeSyntaxIndicatorChange: (Boolean) -> Unit,
     recipeImageUploadFolder: String,
     onRecipeImageUploadFolderClick: () -> Unit,
+    shoppingListName: String?,
+    onShoppingListClick: () -> Unit,
 ) {
     Text(
         text = stringResource(R.string.settings_general),
@@ -284,6 +308,72 @@ fun ColumnScope.SettingsGroupGeneral(
                 imageVector = Icons.Outlined.Folder,
                 contentDescription = null,
             )
+        },
+    )
+    ListItem(
+        headlineContent = {
+            Text(text = stringResource(R.string.settings_shopping_list))
+        },
+        modifier = Modifier.clickable(onClick = onShoppingListClick),
+        supportingContent = {
+            Text(text = shoppingListName ?: stringResource(R.string.settings_shopping_list_none_selected))
+        },
+        leadingContent = {
+            Icon(
+                imageVector = Icons.Outlined.ShoppingCart,
+                contentDescription = null,
+            )
+        },
+    )
+}
+
+@Composable
+fun ShoppingListSelectionDialog(
+    state: ShoppingListDialogState,
+    onSelect: (TaskList) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (state is ShoppingListDialogState.Hidden) return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.settings_shopping_list_dialog_title)) },
+        text = {
+            when (state) {
+                is ShoppingListDialogState.Loading -> {
+                    CircularProgressIndicator()
+                }
+                is ShoppingListDialogState.Loaded -> {
+                    if (state.taskLists.isEmpty()) {
+                        Text(text = stringResource(R.string.settings_shopping_list_empty))
+                    } else {
+                        Column(modifier = Modifier.verticalScroll(state = rememberScrollState())) {
+                            state.taskLists.forEach { taskList ->
+                                ListItem(
+                                    headlineContent = { Text(text = taskList.displayName) },
+                                    modifier = Modifier.clickable(onClick = { onSelect(taskList) }),
+                                    leadingContent = {
+                                        RadioButton(
+                                            selected = taskList.url == state.selectedUrl,
+                                            onClick = { onSelect(taskList) },
+                                        )
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+                is ShoppingListDialogState.Error -> {
+                    Text(text = state.message.asString())
+                }
+                is ShoppingListDialogState.Hidden -> Unit
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.common_cancel))
+            }
         },
     )
 }
@@ -500,6 +590,8 @@ private fun SettingsContentPreview() {
             onShowRecipeSyntaxIndicatorChange = {},
             recipeImageUploadFolder = ".de.lukasneugebauer.nextcloudcookbook",
             onRecipeImageUploadFolderClick = {},
+            shoppingListName = null,
+            onShoppingListClick = {},
             onLogoutClick = {},
             onPrivacyClick = {},
             onLicenseClick = {},

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/settings/presentation/settings/SettingsViewModel.kt
@@ -3,14 +3,21 @@ package de.lukasneugebauer.nextcloudcookbook.settings.presentation.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import de.lukasneugebauer.nextcloudcookbook.R
 import de.lukasneugebauer.nextcloudcookbook.core.data.PreferencesManager
 import de.lukasneugebauer.nextcloudcookbook.core.data.api.NcCookbookApiProvider
 import de.lukasneugebauer.nextcloudcookbook.core.domain.usecase.ClearAllStoresUseCase
 import de.lukasneugebauer.nextcloudcookbook.core.domain.usecase.ClearPreferencesUseCase
+import de.lukasneugebauer.nextcloudcookbook.core.util.Resource
+import de.lukasneugebauer.nextcloudcookbook.core.util.UiText
 import de.lukasneugebauer.nextcloudcookbook.settings.domain.state.SettingsScreenState
+import de.lukasneugebauer.nextcloudcookbook.settings.domain.state.ShoppingListDialogState
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.repository.TasksRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -26,9 +33,14 @@ class SettingsViewModel
         private val clearAllStoresUseCase: ClearAllStoresUseCase,
         private val clearPreferencesUseCase: ClearPreferencesUseCase,
         private val preferencesManager: PreferencesManager,
+        private val tasksRepository: TasksRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<SettingsScreenState>(SettingsScreenState.Initial)
         val uiState = _uiState.asStateFlow()
+
+        private val _shoppingListDialogState =
+            MutableStateFlow<ShoppingListDialogState>(ShoppingListDialogState.Hidden)
+        val shoppingListDialogState = _shoppingListDialogState.asStateFlow()
 
         init {
             preferencesManager.preferencesFlow
@@ -37,6 +49,7 @@ class SettingsViewModel
                         isStayAwake = preferencesManager.getStayAwake(),
                         isShowRecipeSyntaxIndicator = preferences.isShowIngredientSyntaxIndicator,
                         recipeImageUploadFolder = preferences.recipeImageUploadFolder,
+                        shoppingListName = preferences.shoppingList?.displayName,
                     )
                 }.distinctUntilChanged()
                 .onEach { loadedState ->
@@ -58,6 +71,40 @@ class SettingsViewModel
         fun setShowRecipeSyntaxIndicator(isShowRecipeSyntaxIndicator: Boolean) {
             viewModelScope.launch {
                 preferencesManager.updateShowIngredientSyntaxIndicator(isShowRecipeSyntaxIndicator)
+            }
+        }
+
+        fun showShoppingListDialog() {
+            _shoppingListDialogState.value = ShoppingListDialogState.Loading
+            viewModelScope.launch {
+                when (val result = tasksRepository.getTaskLists()) {
+                    is Resource.Success ->
+                        _shoppingListDialogState.value =
+                            ShoppingListDialogState.Loaded(
+                                taskLists = result.data.orEmpty(),
+                                selectedUrl =
+                                    preferencesManager.preferencesFlow
+                                        .first()
+                                        .shoppingList
+                                        ?.url,
+                            )
+                    is Resource.Error ->
+                        _shoppingListDialogState.value =
+                            ShoppingListDialogState.Error(
+                                result.message ?: UiText.StringResource(R.string.settings_shopping_list_error),
+                            )
+                }
+            }
+        }
+
+        fun hideShoppingListDialog() {
+            _shoppingListDialogState.value = ShoppingListDialogState.Hidden
+        }
+
+        fun setShoppingList(taskList: TaskList) {
+            viewModelScope.launch {
+                preferencesManager.updateShoppingList(taskList)
+                _shoppingListDialogState.value = ShoppingListDialogState.Hidden
             }
         }
 

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/data/remote/CalDavXmlParser.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/data/remote/CalDavXmlParser.kt
@@ -1,0 +1,75 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.data.remote
+
+import org.w3c.dom.Element
+import javax.xml.parsers.DocumentBuilderFactory
+
+data class CalDavCalendar(
+    val href: String,
+    val displayName: String,
+)
+
+class CalDavXmlParser {
+    /**
+     * Parses a CalDAV PROPFIND multistatus response and returns all calendars
+     * that support VTODO components, i.e. Nextcloud Tasks lists.
+     */
+    fun parseTaskLists(xml: String): List<CalDavCalendar> {
+        val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
+        val document = factory.newDocumentBuilder().parse(xml.byteInputStream())
+        val responses = document.getElementsByTagNameNS(NS_DAV, "response")
+
+        val calendars = mutableListOf<CalDavCalendar>()
+        for (i in 0 until responses.length) {
+            val response = responses.item(i) as? Element ?: continue
+            val href =
+                response
+                    .getElementsByTagNameNS(NS_DAV, "href")
+                    .item(0)
+                    ?.textContent
+                    ?.trim()
+                    ?: continue
+
+            if (!isCalendar(response) || !supportsVTodo(response)) continue
+
+            val displayName =
+                textContents(response, NS_DAV, "displayname")
+                    .firstOrNull { it.isNotBlank() }
+                    ?: href.trimEnd('/').substringAfterLast('/')
+
+            calendars.add(CalDavCalendar(href = href, displayName = displayName))
+        }
+        return calendars
+    }
+
+    private fun isCalendar(response: Element): Boolean {
+        val resourceTypes = response.getElementsByTagNameNS(NS_DAV, "resourcetype")
+        for (i in 0 until resourceTypes.length) {
+            val resourceType = resourceTypes.item(i) as? Element ?: continue
+            if (resourceType.getElementsByTagNameNS(NS_CALDAV, "calendar").length > 0) return true
+        }
+        return false
+    }
+
+    private fun supportsVTodo(response: Element): Boolean {
+        val comps = response.getElementsByTagNameNS(NS_CALDAV, "comp")
+        for (i in 0 until comps.length) {
+            val comp = comps.item(i) as? Element ?: continue
+            if (comp.getAttribute("name").equals("VTODO", ignoreCase = true)) return true
+        }
+        return false
+    }
+
+    private fun textContents(
+        element: Element,
+        namespace: String,
+        localName: String,
+    ): List<String> {
+        val nodes = element.getElementsByTagNameNS(namespace, localName)
+        return (0 until nodes.length).mapNotNull { nodes.item(it)?.textContent?.trim() }
+    }
+
+    companion object {
+        private const val NS_DAV = "DAV:"
+        private const val NS_CALDAV = "urn:ietf:params:xml:ns:caldav"
+    }
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/data/repository/TasksRepositoryImpl.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/data/repository/TasksRepositoryImpl.kt
@@ -1,0 +1,171 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.data.repository
+
+import de.lukasneugebauer.nextcloudcookbook.R
+import de.lukasneugebauer.nextcloudcookbook.core.data.PreferencesManager
+import de.lukasneugebauer.nextcloudcookbook.core.domain.model.NcAccount
+import de.lukasneugebauer.nextcloudcookbook.core.util.OkHttpClientProvider
+import de.lukasneugebauer.nextcloudcookbook.core.util.Resource
+import de.lukasneugebauer.nextcloudcookbook.core.util.UiText
+import de.lukasneugebauer.nextcloudcookbook.core.util.addSuffix
+import de.lukasneugebauer.nextcloudcookbook.tasks.data.remote.CalDavXmlParser
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.repository.TasksRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import timber.log.Timber
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class TasksRepositoryImpl(
+    private val clientProvider: OkHttpClientProvider,
+    private val preferencesManager: PreferencesManager,
+    private val ioDispatcher: CoroutineDispatcher,
+    private val parser: CalDavXmlParser,
+) : TasksRepository {
+    override suspend fun getTaskLists(): Resource<List<TaskList>> =
+        withContext(ioDispatcher) {
+            try {
+                val account = preferencesManager.preferencesFlow.first().ncAccount
+                val baseUrl =
+                    account.url.addSuffix("/").toHttpUrlOrNull()
+                        ?: return@withContext Resource.Error(UiText.StringResource(R.string.error_unknown))
+                val calendarsUrl =
+                    baseUrl
+                        .newBuilder()
+                        .addPathSegments("remote.php/dav/calendars")
+                        .addPathSegment(account.username)
+                        .addPathSegment("")
+                        .build()
+
+                val request =
+                    Request
+                        .Builder()
+                        .url(calendarsUrl)
+                        .method("PROPFIND", PROPFIND_BODY.toRequestBody(XML_MEDIA_TYPE))
+                        .header("Authorization", basicAuth(account))
+                        .header("Depth", "1")
+                        .build()
+
+                clientProvider.getCurrentClient().newCall(request).execute().use { response ->
+                    val body = response.body?.string()
+                    if (!response.isSuccessful || body == null) {
+                        Timber.e("PROPFIND for task lists failed with code ${response.code}")
+                        return@withContext Resource.Error(UiText.StringResource(R.string.settings_shopping_list_error))
+                    }
+
+                    val taskLists =
+                        parser.parseTaskLists(body).mapNotNull { calendar ->
+                            baseUrl
+                                .resolve(calendar.href)
+                                ?.toString()
+                                ?.let { TaskList(url = it, displayName = calendar.displayName) }
+                        }
+                    Resource.Success(taskLists)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Loading task lists failed")
+                Resource.Error(UiText.StringResource(R.string.settings_shopping_list_error))
+            }
+        }
+
+    override suspend fun createTasks(
+        listUrl: String,
+        summaries: List<String>,
+    ): Resource<Int> =
+        withContext(ioDispatcher) {
+            try {
+                val account = preferencesManager.preferencesFlow.first().ncAccount
+                val client = clientProvider.getCurrentClient()
+                var created = 0
+
+                summaries.forEach { summary ->
+                    val uid = UUID.randomUUID().toString()
+                    val taskUrl =
+                        listUrl.addSuffix("/").toHttpUrlOrNull()?.resolve("$uid.ics")
+                            ?: return@withContext Resource.Error(UiText.StringResource(R.string.shopping_list_error_adding))
+
+                    val request =
+                        Request
+                            .Builder()
+                            .url(taskUrl)
+                            .put(buildVTodo(uid, summary).toRequestBody(CALENDAR_MEDIA_TYPE))
+                            .header("Authorization", basicAuth(account))
+                            .header("If-None-Match", "*")
+                            .build()
+
+                    client.newCall(request).execute().use { response ->
+                        if (response.isSuccessful) {
+                            created++
+                        } else {
+                            Timber.e("Creating task failed with code ${response.code}")
+                        }
+                    }
+                }
+
+                if (created == summaries.size) {
+                    Resource.Success(created)
+                } else {
+                    Resource.Error(UiText.StringResource(R.string.shopping_list_error_adding), created)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Creating tasks failed")
+                Resource.Error(UiText.StringResource(R.string.shopping_list_error_adding))
+            }
+        }
+
+    private fun basicAuth(account: NcAccount): String = Credentials.basic(account.username, account.token, UTF_8)
+
+    private fun buildVTodo(
+        uid: String,
+        summary: String,
+    ): String {
+        val timestamp = TIMESTAMP_FORMATTER.format(Instant.now())
+        val escapedSummary =
+            summary
+                .replace("\\", "\\\\")
+                .replace(";", "\\;")
+                .replace(",", "\\,")
+                .replace("\r\n", "\\n")
+                .replace("\n", "\\n")
+
+        return listOf(
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//Nextcloud Cookbook Android//EN",
+            "BEGIN:VTODO",
+            "UID:$uid",
+            "CREATED:$timestamp",
+            "DTSTAMP:$timestamp",
+            "LAST-MODIFIED:$timestamp",
+            "SUMMARY:$escapedSummary",
+            "END:VTODO",
+            "END:VCALENDAR",
+        ).joinToString(separator = "\r\n", postfix = "\r\n")
+    }
+
+    companion object {
+        private val XML_MEDIA_TYPE = "application/xml; charset=utf-8".toMediaType()
+        private val CALENDAR_MEDIA_TYPE = "text/calendar; charset=utf-8".toMediaType()
+        private val TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC)
+        private val PROPFIND_BODY =
+            """
+            <d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+              <d:prop>
+                <d:resourcetype/>
+                <d:displayname/>
+                <c:supported-calendar-component-set/>
+              </d:prop>
+            </d:propfind>
+            """.trimIndent()
+    }
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/domain/model/TaskList.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/domain/model/TaskList.kt
@@ -1,0 +1,6 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.domain.model
+
+data class TaskList(
+    val url: String,
+    val displayName: String,
+)

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/domain/repository/TasksRepository.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/domain/repository/TasksRepository.kt
@@ -1,0 +1,13 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.domain.repository
+
+import de.lukasneugebauer.nextcloudcookbook.core.util.Resource
+import de.lukasneugebauer.nextcloudcookbook.tasks.domain.model.TaskList
+
+interface TasksRepository {
+    suspend fun getTaskLists(): Resource<List<TaskList>>
+
+    suspend fun createTasks(
+        listUrl: String,
+        summaries: List<String>,
+    ): Resource<Int>
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/presentation/AddToShoppingListDialog.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/presentation/AddToShoppingListDialog.kt
@@ -1,0 +1,122 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import de.lukasneugebauer.nextcloudcookbook.R
+import de.lukasneugebauer.nextcloudcookbook.core.presentation.ui.theme.NextcloudCookbookTheme
+import de.lukasneugebauer.nextcloudcookbook.tasks.util.IngredientQuantityParser
+
+@Composable
+fun AddToShoppingListDialog(
+    ingredients: List<String>,
+    onConfirm: (List<String>) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val items = remember(ingredients) { ingredients.map { it.trim() to IngredientQuantityParser.parse(it) } }
+    val includedStates = remember(items) { items.map { true }.toMutableStateList() }
+    val withQuantityStates = remember(items) { items.map { true }.toMutableStateList() }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.shopping_list_dialog_title)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(state = rememberScrollState())) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    Box(
+                        modifier = Modifier.width(CHECKBOX_COLUMN_WIDTH),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.shopping_list_dialog_amount),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                }
+                items.forEachIndexed { index, (original, parsed) ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = includedStates[index],
+                            onCheckedChange = { includedStates[index] = it },
+                        )
+                        Text(
+                            text = original,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (parsed.quantity != null) {
+                            Checkbox(
+                                checked = withQuantityStates[index],
+                                onCheckedChange = { withQuantityStates[index] = it },
+                                enabled = includedStates[index],
+                            )
+                        } else {
+                            Spacer(modifier = Modifier.size(CHECKBOX_COLUMN_WIDTH))
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val entries =
+                        items.mapIndexedNotNull { index, (original, parsed) ->
+                            when {
+                                !includedStates[index] -> null
+                                parsed.quantity != null && !withQuantityStates[index] -> parsed.name
+                                else -> original
+                            }
+                        }
+                    onConfirm(entries)
+                },
+                enabled = includedStates.any { it },
+            ) {
+                Text(text = stringResource(R.string.common_add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.common_cancel))
+            }
+        },
+    )
+}
+
+private val CHECKBOX_COLUMN_WIDTH = 48.dp
+
+@Preview
+@Composable
+private fun AddToShoppingListDialogPreview() {
+    NextcloudCookbookTheme {
+        AddToShoppingListDialog(
+            ingredients =
+                listOf(
+                    "200 g Mehl",
+                    "1/2 TL Salz",
+                    "Pfeffer nach Geschmack",
+                ),
+            onConfirm = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/util/IngredientQuantityParser.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/tasks/util/IngredientQuantityParser.kt
@@ -1,0 +1,167 @@
+package de.lukasneugebauer.nextcloudcookbook.tasks.util
+
+import java.util.Locale
+
+data class ParsedIngredient(
+    val quantity: String?,
+    val name: String,
+)
+
+/**
+ * Splits an ingredient string like "200 g flour" into its quantity part ("200 g")
+ * and its name ("flour"). If no leading quantity is recognized, [ParsedIngredient.quantity]
+ * is null and the whole string is treated as the name.
+ */
+object IngredientQuantityParser {
+    private val AMOUNT_REGEX =
+        Regex("""^(?:(?:\d+\s+)?\d+\s*/\s*\d+|(?:\d+\s+)?\p{No}|\d+(?:[.,]\d+)?(?:\s*-\s*\d+(?:[.,]\d+)?)?)""")
+    private val ATTACHED_UNIT_REGEX = Regex("""^\p{L}+\.?""")
+
+    private val UNITS =
+        setOf(
+            // German
+            "g",
+            "gr",
+            "gramm",
+            "kg",
+            "kilogramm",
+            "mg",
+            "ml",
+            "milliliter",
+            "cl",
+            "dl",
+            "l",
+            "liter",
+            "tl",
+            "teelöffel",
+            "el",
+            "esslöffel",
+            "msp",
+            "messerspitze",
+            "messerspitzen",
+            "prise",
+            "prisen",
+            "pkt",
+            "pck",
+            "päckchen",
+            "packung",
+            "packungen",
+            "dose",
+            "dosen",
+            "glas",
+            "gläser",
+            "becher",
+            "bund",
+            "zehe",
+            "zehen",
+            "stück",
+            "stk",
+            "scheibe",
+            "scheiben",
+            "blatt",
+            "blätter",
+            "stange",
+            "stangen",
+            "würfel",
+            "tropfen",
+            "schuss",
+            "handvoll",
+            "tasse",
+            "tassen",
+            "zweig",
+            "zweige",
+            "kopf",
+            "köpfe",
+            "knolle",
+            "knollen",
+            "portion",
+            "portionen",
+            "cm",
+            // English
+            "tsp",
+            "teaspoon",
+            "teaspoons",
+            "tbsp",
+            "tbs",
+            "tablespoon",
+            "tablespoons",
+            "cup",
+            "cups",
+            "oz",
+            "ounce",
+            "ounces",
+            "lb",
+            "lbs",
+            "pound",
+            "pounds",
+            "pinch",
+            "pinches",
+            "clove",
+            "cloves",
+            "can",
+            "cans",
+            "slice",
+            "slices",
+            "stick",
+            "sticks",
+            "dash",
+            "dashes",
+            "bunch",
+            "bunches",
+            "package",
+            "packages",
+            "packet",
+            "packets",
+            "piece",
+            "pieces",
+            "drop",
+            "drops",
+            "head",
+            "heads",
+            "sprig",
+            "sprigs",
+            "quart",
+            "quarts",
+            "pint",
+            "pints",
+            "gallon",
+            "gallons",
+            "stalk",
+            "stalks",
+        )
+
+    fun parse(ingredient: String): ParsedIngredient {
+        val trimmed = ingredient.trim()
+        val amountMatch =
+            AMOUNT_REGEX.find(trimmed)
+                ?: return ParsedIngredient(quantity = null, name = trimmed)
+        var quantityEnd = amountMatch.range.last + 1
+        val afterAmount = trimmed.substring(quantityEnd)
+
+        if (afterAmount.isNotEmpty() && !afterAmount.first().isWhitespace()) {
+            // Unit directly attached to the amount, e.g. "200g flour"
+            val attached = ATTACHED_UNIT_REGEX.find(afterAmount)
+            if (attached == null || !isUnit(attached.value)) {
+                return ParsedIngredient(quantity = null, name = trimmed)
+            }
+            quantityEnd += attached.value.length
+        } else {
+            val firstToken =
+                trimmed
+                    .substring(quantityEnd)
+                    .trim()
+                    .takeWhile { !it.isWhitespace() }
+            if (firstToken.isNotEmpty() && isUnit(firstToken)) {
+                quantityEnd = trimmed.indexOf(firstToken, quantityEnd) + firstToken.length
+            }
+        }
+
+        val name = trimmed.substring(quantityEnd).trim()
+        if (name.isEmpty()) {
+            return ParsedIngredient(quantity = null, name = trimmed)
+        }
+        return ParsedIngredient(quantity = trimmed.substring(0, quantityEnd).trim(), name = name)
+    }
+
+    private fun isUnit(token: String): Boolean = token.trimEnd('.').lowercase(Locale.ROOT) in UNITS
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,6 +5,7 @@
     <string name="common_add">Hinzufügen</string>
     <string name="common_ascending">Aufsteigend</string>
     <string name="common_back">Zurück</string>
+    <string name="common_cancel">Abbrechen</string>
     <string name="common_categories">Kategorien</string>
     <string name="common_clear_input">Eingabe löschen</string>
     <string name="common_close">Schließen</string>
@@ -87,6 +88,7 @@
         <item quantity="other">Zutaten kopiert</item>
     </plurals>
     <string name="recipe_ingredients_copy">Zutaten in Zwischenablage kopieren</string>
+    <string name="recipe_ingredients_add_to_shopping_list">Zutaten zur Einkaufsliste hinzufügen</string>
     <plurals name="recipe_ingredients_servings">
         <item quantity="one">Zutaten für %1$d Portion</item>
         <item quantity="other">Zutaten für %1$d Portionen</item>
@@ -153,7 +155,20 @@
     <string name="settings_paypal">PayPal</string>
     <string name="settings_paypal_donation">Spenden über PayPal</string>
     <string name="settings_privacy">Datenschutz</string>
+    <string name="settings_shopping_list">Einkaufsliste</string>
+    <string name="settings_shopping_list_none_selected">Keine Liste ausgewählt</string>
+    <string name="settings_shopping_list_dialog_title">Einkaufsliste auswählen</string>
+    <string name="settings_shopping_list_empty">Keine Aufgabenlisten gefunden.</string>
+    <string name="settings_shopping_list_error">Aufgabenlisten konnten nicht geladen werden.</string>
     <string name="settings_show_indicator_if_recipe_syntax_is_invalid">Zeigt einen Hinweis an, wenn die Syntax der Zutaten für die Neuberechnung ungeeignet ist.</string>
+    <string name="shopping_list_dialog_title">Zur Einkaufsliste hinzufügen</string>
+    <string name="shopping_list_dialog_amount">Menge</string>
+    <string name="shopping_list_not_configured">Bitte zuerst in den Einstellungen eine Einkaufsliste auswählen.</string>
+    <string name="shopping_list_error_adding">Zutaten konnten nicht zur Einkaufsliste hinzugefügt werden.</string>
+    <plurals name="shopping_list_ingredients_added">
+        <item quantity="one">%1$d Zutat zur Einkaufsliste hinzugefügt</item>
+        <item quantity="other">%1$d Zutaten zur Einkaufsliste hinzugefügt</item>
+    </plurals>
     <string name="settings_source_code">Quellcode</string>
     <string name="settings_sponsoring">Unterstützen</string>
     <string name="settings_stay_awake_on_recipe_screen">Der Bildschirm bleibt eingeschaltet, während Sie sich auf dem Rezeptbildschirm befinden</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="common_add">Add</string>
     <string name="common_ascending">Ascending</string>
     <string name="common_back">Back</string>
+    <string name="common_cancel">Cancel</string>
     <string name="common_categories">Categories</string>
     <string name="common_clear_input">Clear input</string>
     <string name="common_close">Close</string>
@@ -92,6 +93,7 @@
         <item quantity="other">Copied ingredients</item>
     </plurals>
     <string name="recipe_ingredients_copy">Copy ingredients to clipboard</string>
+    <string name="recipe_ingredients_add_to_shopping_list">Add ingredients to shopping list</string>
     <plurals name="recipe_ingredients_servings">
         <item quantity="one">Ingredients for %1$d serving</item>
         <item quantity="other">Ingredients for %1$d servings</item>
@@ -162,7 +164,20 @@
     <string name="settings_paypal">PayPal</string>
     <string name="settings_paypal_donation">Donate via PayPal</string>
     <string name="settings_privacy">Privacy</string>
+    <string name="settings_shopping_list">Shopping list</string>
+    <string name="settings_shopping_list_none_selected">No list selected</string>
+    <string name="settings_shopping_list_dialog_title">Select shopping list</string>
+    <string name="settings_shopping_list_empty">No task lists found.</string>
+    <string name="settings_shopping_list_error">Task lists couldn\'t be loaded.</string>
     <string name="settings_show_indicator_if_recipe_syntax_is_invalid">Show an indicator if the syntax of the ingredients is unsuitable for recalculation.</string>
+    <string name="shopping_list_dialog_title">Add to shopping list</string>
+    <string name="shopping_list_dialog_amount">Amount</string>
+    <string name="shopping_list_not_configured">Select a shopping list in the settings first.</string>
+    <string name="shopping_list_error_adding">Ingredients couldn\'t be added to the shopping list.</string>
+    <plurals name="shopping_list_ingredients_added">
+        <item quantity="one">Added %1$d ingredient to the shopping list</item>
+        <item quantity="other">Added %1$d ingredients to the shopping list</item>
+    </plurals>
     <string name="settings_source_code">Get source code</string>
     <string name="settings_sponsoring">Sponsoring</string>
     <string name="settings_stay_awake_on_recipe_screen">Screen stays on while you are on the recipe screen</string>

--- a/app/src/test/java/de/lukasneugebauer/nextcloudcookbook/CalDavXmlParserUnitTest.kt
+++ b/app/src/test/java/de/lukasneugebauer/nextcloudcookbook/CalDavXmlParserUnitTest.kt
@@ -1,0 +1,108 @@
+package de.lukasneugebauer.nextcloudcookbook
+
+import de.lukasneugebauer.nextcloudcookbook.tasks.data.remote.CalDavXmlParser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CalDavXmlParserUnitTest {
+    private val parser = CalDavXmlParser()
+
+    @Test
+    fun multistatus_WithMixedCalendars_ReturnsOnlyVTodoCalendars() {
+        val xml =
+            """
+            <?xml version="1.0"?>
+            <d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+                <d:response>
+                    <d:href>/remote.php/dav/calendars/user/</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:resourcetype><d:collection/></d:resourcetype>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+                <d:response>
+                    <d:href>/remote.php/dav/calendars/user/personal/</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:resourcetype><d:collection/><cal:calendar/></d:resourcetype>
+                            <d:displayname>Personal</d:displayname>
+                            <cal:supported-calendar-component-set>
+                                <cal:comp name="VEVENT"/>
+                            </cal:supported-calendar-component-set>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+                <d:response>
+                    <d:href>/remote.php/dav/calendars/user/einkaufsliste/</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:resourcetype><d:collection/><cal:calendar/></d:resourcetype>
+                            <d:displayname>Einkaufsliste</d:displayname>
+                            <cal:supported-calendar-component-set>
+                                <cal:comp name="VTODO"/>
+                            </cal:supported-calendar-component-set>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+            </d:multistatus>
+            """.trimIndent()
+
+        val calendars = parser.parseTaskLists(xml)
+
+        assertEquals(1, calendars.size)
+        assertEquals("/remote.php/dav/calendars/user/einkaufsliste/", calendars[0].href)
+        assertEquals("Einkaufsliste", calendars[0].displayName)
+    }
+
+    @Test
+    fun multistatus_WithoutDisplayName_FallsBackToHrefSegment() {
+        val xml =
+            """
+            <?xml version="1.0"?>
+            <d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+                <d:response>
+                    <d:href>/remote.php/dav/calendars/user/tasks/</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:resourcetype><d:collection/><cal:calendar/></d:resourcetype>
+                            <cal:supported-calendar-component-set>
+                                <cal:comp name="VTODO"/>
+                            </cal:supported-calendar-component-set>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+            </d:multistatus>
+            """.trimIndent()
+
+        val calendars = parser.parseTaskLists(xml)
+
+        assertEquals(1, calendars.size)
+        assertEquals("tasks", calendars[0].displayName)
+    }
+
+    @Test
+    fun multistatus_WithoutCalendars_ReturnsEmptyList() {
+        val xml =
+            """
+            <?xml version="1.0"?>
+            <d:multistatus xmlns:d="DAV:">
+                <d:response>
+                    <d:href>/remote.php/dav/calendars/user/</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:resourcetype><d:collection/></d:resourcetype>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+            </d:multistatus>
+            """.trimIndent()
+
+        assertEquals(0, parser.parseTaskLists(xml).size)
+    }
+}

--- a/app/src/test/java/de/lukasneugebauer/nextcloudcookbook/IngredientQuantityParserUnitTest.kt
+++ b/app/src/test/java/de/lukasneugebauer/nextcloudcookbook/IngredientQuantityParserUnitTest.kt
@@ -1,0 +1,99 @@
+package de.lukasneugebauer.nextcloudcookbook
+
+import de.lukasneugebauer.nextcloudcookbook.tasks.util.IngredientQuantityParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class IngredientQuantityParserUnitTest {
+    @Test
+    fun ingredient_WithAmountAndSeparateUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("200 g Mehl")
+        assertEquals("200 g", result.quantity)
+        assertEquals("Mehl", result.name)
+    }
+
+    @Test
+    fun ingredient_WithAttachedUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("200g Mehl")
+        assertEquals("200g", result.quantity)
+        assertEquals("Mehl", result.name)
+    }
+
+    @Test
+    fun ingredient_WithFractionAndUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("1/2 TL Salz")
+        assertEquals("1/2 TL", result.quantity)
+        assertEquals("Salz", result.name)
+    }
+
+    @Test
+    fun ingredient_WithUnicodeFraction_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("½ Zwiebel")
+        assertEquals("½", result.quantity)
+        assertEquals("Zwiebel", result.name)
+    }
+
+    @Test
+    fun ingredient_WithMixedNumberAndUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("1 1/2 Tassen Zucker")
+        assertEquals("1 1/2 Tassen", result.quantity)
+        assertEquals("Zucker", result.name)
+    }
+
+    @Test
+    fun ingredient_WithRange_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("2-3 Äpfel")
+        assertEquals("2-3", result.quantity)
+        assertEquals("Äpfel", result.name)
+    }
+
+    @Test
+    fun ingredient_WithDecimalAmount_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("2,5 kg Kartoffeln")
+        assertEquals("2,5 kg", result.quantity)
+        assertEquals("Kartoffeln", result.name)
+    }
+
+    @Test
+    fun ingredient_WithAmountWithoutUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("2 rote Zwiebeln")
+        assertEquals("2", result.quantity)
+        assertEquals("rote Zwiebeln", result.name)
+    }
+
+    @Test
+    fun ingredient_WithUnitWithTrailingDot_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("1 Pck. Vanillezucker")
+        assertEquals("1 Pck.", result.quantity)
+        assertEquals("Vanillezucker", result.name)
+    }
+
+    @Test
+    fun ingredient_WithEnglishUnit_ReturnsQuantityAndName() {
+        val result = IngredientQuantityParser.parse("1 cup flour")
+        assertEquals("1 cup", result.quantity)
+        assertEquals("flour", result.name)
+    }
+
+    @Test
+    fun ingredient_WithoutAmount_ReturnsNullQuantity() {
+        val result = IngredientQuantityParser.parse("Salz und Pfeffer nach Geschmack")
+        assertNull(result.quantity)
+        assertEquals("Salz und Pfeffer nach Geschmack", result.name)
+    }
+
+    @Test
+    fun ingredient_WithAttachedNonUnit_ReturnsNullQuantity() {
+        val result = IngredientQuantityParser.parse("1er Springform")
+        assertNull(result.quantity)
+        assertEquals("1er Springform", result.name)
+    }
+
+    @Test
+    fun ingredient_WithAmountOnly_ReturnsNullQuantity() {
+        val result = IngredientQuantityParser.parse("200 g")
+        assertNull(result.quantity)
+        assertEquals("200 g", result.name)
+    }
+}


### PR DESCRIPTION
## What this PR does

Adds the ability to send a recipe's ingredients directly to a **Nextcloud Tasks list** (e.g. a shopping list) from the recipe detail screen.

### User-facing changes

**1. New "Add to shopping list" button on the recipe detail screen**

Next to the existing copy-ingredients button there is now a shopping-cart button. Tapping it opens a selection dialog with one row per ingredient and three columns:

- **Left checkbox** – whether the ingredient should be transferred at all (checked by default)
- **Middle** – the ingredient as currently displayed (i.e. with quantities recalculated for the selected number of servings)
- **Right checkbox** – whether the quantity should be included (checked by default). If unchecked, only the ingredient name is transferred (e.g. "Flour" instead of "200 g Flour"). For ingredients where no quantity can be detected (e.g. "Salt and pepper to taste") this checkbox is hidden.

Section headlines (`## …`) inside the ingredient list are excluded from the dialog. Each transferred ingredient becomes its **own task** in the target list, so items can be ticked off individually while shopping. If no shopping list has been configured yet, a toast points the user to the settings.

**2. New "Shopping list" setting**

Settings → General now has a "Shopping list" entry. It loads all task lists of the user's Nextcloud account and lets the user pick which one to use as shopping list. The selection is persisted in the preferences DataStore.

### Implementation notes

- **CalDAV integration** (new `tasks` feature package following the existing Clean Architecture layout): Nextcloud Tasks has no dedicated REST API, so task lists are discovered via a `PROPFIND` request on `remote.php/dav/calendars/{user}/` (Depth 1), filtered to calendars that support `VTODO` components. Tasks are created with one `PUT` per ingredient containing a minimal `VCALENDAR`/`VTODO` (with `If-None-Match: *` to avoid overwrites). The existing app password is used for Basic auth, and the shared `OkHttpClientProvider` is reused so the self-signed-certificate setting keeps working.
- **Quantity detection** (`IngredientQuantityParser`): splits the leading amount and unit from the ingredient name. Handles decimals (`2,5 kg`), fractions (`1/2`, `½`, `1 1/2`), ranges (`2-3`), attached units (`200g`) and a list of common German and English units. Words that are not known units are treated as part of the name, so "2 rote Zwiebeln" correctly yields the quantity "2" and the name "rote Zwiebeln".
- The `PROPFIND` multistatus response is parsed with a namespace-aware DOM parser (`CalDavXmlParser`), which is covered by unit tests.
- New strings were added to `values/strings.xml` (English) and `values-de/strings.xml` (German).

### Testing

- 16 new unit tests for `IngredientQuantityParser` and `CalDavXmlParser` (all green, `testFullDebugUnitTest`)
- `ktlintCheck` passes
- Manually tested against a real Nextcloud instance: task lists load in the settings, and selected ingredients show up as individual tasks in the chosen list (with and without quantities, and with adjusted servings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure a Nextcloud shopping list in Settings.
  * Add selected recipe ingredients to the configured shopping list.
  * Choose whether to include ingredient quantities.
  * View success or error feedback after adding ingredients.
  * Automatically discover available task lists.
* **Localization**
  * Added English and German translations for shopping-list features.
* **Tests**
  * Added coverage for task-list discovery and ingredient quantity parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->