### PR TITLE
Fix configureTrustAllCertificates

### DIFF
--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import timber.log.Timber
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.inject.Inject
@@ -76,7 +77,7 @@ class OkHttpClientProvider
                     .sslSocketFactory(sslContext.socketFactory, trustManager)
                     .hostnameVerifier { _, _ -> true }
             } catch (e: Exception) {
-                // Do nothing if SSL configuration fails, keep default settings
+                Timber.e(e, "Could not configure trust-all TLS")
             }
         }
     }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
@@ -51,33 +51,32 @@ class OkHttpClientProvider
         fun getCurrentClient(): OkHttpClient = _clientFlow.value
 
         @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
-private fun configureTrustAllCertificates(builder: OkHttpClient.Builder) {
-    try {
-        val trustAllCerts =
-            arrayOf<TrustManager>(
-                object : X509TrustManager {
-                    override fun checkClientTrusted(
-                        chain: Array<X509Certificate>,
-                        authType: String,
-                    ) {}
+        private fun configureTrustAllCertificates(builder: OkHttpClient.Builder) {
+            try {
+                val trustManager =
+                    object : X509TrustManager {
+                        override fun checkClientTrusted(
+                            chain: Array<X509Certificate>,
+                            authType: String,
+                        ) {}
 
-                    override fun checkServerTrusted(
-                        chain: Array<X509Certificate>,
-                        authType: String,
-                    ) {}
+                        override fun checkServerTrusted(
+                            chain: Array<X509Certificate>,
+                            authType: String,
+                        ) {}
 
-                    override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-                },
-            )
+                        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+                    }
+                val trustAllCerts = arrayOf<TrustManager>(trustManager)
 
-        val sslContext = SSLContext.getInstance("TLSv1.2")
-        sslContext.init(null, trustAllCerts, SecureRandom())
+                val sslContext = SSLContext.getInstance("TLS")
+                sslContext.init(null, trustAllCerts, SecureRandom())
 
-        builder
-            .sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
-            .hostnameVerifier { _, _ -> true }
-    } catch (e: Exception) {
-        // Do nothing if SSL configuration fails, keep default settings
-    }
-}
+                builder
+                    .sslSocketFactory(sslContext.socketFactory, trustManager)
+                    .hostnameVerifier { _, _ -> true }
+            } catch (e: Exception) {
+                // Do nothing if SSL configuration fails, keep default settings
+            }
+        }
     }

--- a/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
+++ b/app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt
@@ -51,33 +51,33 @@ class OkHttpClientProvider
         fun getCurrentClient(): OkHttpClient = _clientFlow.value
 
         @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
-        private fun configureTrustAllCertificates(builder: OkHttpClient.Builder) {
-            try {
-                val trustAllCerts =
-                    arrayOf<TrustManager>(
-                        object : X509TrustManager {
-                            override fun checkClientTrusted(
-                                chain: Array<X509Certificate>,
-                                authType: String,
-                            ) {}
+private fun configureTrustAllCertificates(builder: OkHttpClient.Builder) {
+    try {
+        val trustAllCerts =
+            arrayOf<TrustManager>(
+                object : X509TrustManager {
+                    override fun checkClientTrusted(
+                        chain: Array<X509Certificate>,
+                        authType: String,
+                    ) {}
 
-                            override fun checkServerTrusted(
-                                chain: Array<X509Certificate>,
-                                authType: String,
-                            ) {}
+                    override fun checkServerTrusted(
+                        chain: Array<X509Certificate>,
+                        authType: String,
+                    ) {}
 
-                            override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-                        },
-                    )
+                    override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+                },
+            )
 
-                val sslContext = SSLContext.getInstance("SSL")
-                sslContext.init(null, trustAllCerts, SecureRandom())
+        val sslContext = SSLContext.getInstance("TLSv1.2")
+        sslContext.init(null, trustAllCerts, SecureRandom())
 
-                builder
-                    .sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
-                    .hostnameVerifier { _, _ -> true }
-            } catch (e: Exception) {
-                // Do nothing if SSL configuration fails, keep default settings
-            }
-        }
+        builder
+            .sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
+            .hostnameVerifier { _, _ -> true }
+    } catch (e: Exception) {
+        // Do nothing if SSL configuration fails, keep default settings
+    }
+}
     }


### PR DESCRIPTION
## Analysis context

| Property | Value |
|---|---|
| Method | `configureTrustAllCertificates` |
| Class | `de.lukasneugebauer.nextcloudcookbook.core.util.OkHttpClientProvider` |
| File | `app/src/main/java/de/lukasneugebauer/nextcloudcookbook/core/util/OkHttpClientProvider.kt` |
| Specification | `SSLContextSpec` |
| Analysis tool | `ape` |

## Proposed change

The context is initialized immediately after creation, so the disallowed protocol is consumed by `sslContext.init(...)`. Replacing only `"SSL"` with `"TLSv1.2"` satisfies the confirmed specification predicate without changing the method signature, trust-manager behavior, or call sites.

## Validation

- [x] Change limited to the related file
- [x] Manual review required
- [ ] Confirmed by a project maintainer

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability when establishing secure connections using the TLS protocol.
  * Improved handling and logging of secure connection configuration failures.
  * Preserved existing certificate trust handling and hostname verification behavior.
  * Existing error-handling behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->